### PR TITLE
fix: fix `as_dataframe`

### DIFF
--- a/google/cloud/monitoring_v3/_dataframe.py
+++ b/google/cloud/monitoring_v3/_dataframe.py
@@ -99,7 +99,10 @@ def _build_dataframe(time_series_iterable, label=None, labels=None):  # pragma: 
     for time_series in time_series_iterable:
         pandas_series = pandas.Series(
             data=[_extract_value(point.value) for point in time_series.points],
-            index=[point.interval.end_time.timestamp_pb().ToNanoseconds() for point in time_series.points],
+            index=[
+                point.interval.end_time.timestamp_pb().ToNanoseconds()
+                for point in time_series.points
+            ],
         )
         columns.append(pandas_series)
         headers.append(_extract_header(time_series))

--- a/google/cloud/monitoring_v3/_dataframe.py
+++ b/google/cloud/monitoring_v3/_dataframe.py
@@ -99,7 +99,7 @@ def _build_dataframe(time_series_iterable, label=None, labels=None):  # pragma: 
     for time_series in time_series_iterable:
         pandas_series = pandas.Series(
             data=[_extract_value(point.value) for point in time_series.points],
-            index=[point.interval.end_time for point in time_series.points],
+            index=[point.interval.end_time.timestamp_pb().ToNanoseconds() for point in time_series.points],
         )
         columns.append(pandas_series)
         headers.append(_extract_header(time_series))

--- a/google/cloud/monitoring_v3/_dataframe.py
+++ b/google/cloud/monitoring_v3/_dataframe.py
@@ -21,14 +21,15 @@ try:
 except ImportError:  # pragma: NO COVER
     pandas = None
 
-from google.cloud.monitoring_v3.types import TimeSeries
+from google.cloud import monitoring_v3
+
 
 TOP_RESOURCE_LABELS = ("project_id", "aws_account", "location", "region", "zone")
 
 
 def _extract_header(time_series):
     """Return a copy of time_series with the points removed."""
-    return TimeSeries(
+    return monitoring_v3.TimeSeries(
         metric=time_series.metric,
         resource=time_series.resource,
         metric_kind=time_series.metric_kind,
@@ -46,15 +47,15 @@ def _extract_labels(time_series):
 
 def _extract_value(typed_value):
     """Extract the value from a TypedValue."""
-    value_type = typed_value.WhichOneof("value")
-    return typed_value.__getattribute__(value_type)
+    value_type = monitoring_v3.TypedValue.pb(typed_value).WhichOneof("value")
+    return getattr(typed_value, value_type)
 
 
 def _build_dataframe(time_series_iterable, label=None, labels=None):  # pragma: NO COVER
     """Build a :mod:`pandas` dataframe out of time series.
 
     :type time_series_iterable:
-        iterable over :class:`~google.cloud.monitoring_v3.types.TimeSeries`
+        iterable over :class:`~google.cloud.monitoring_v3.TimeSeries`
     :param time_series_iterable:
         An iterable (e.g., a query object) yielding time series.
 
@@ -94,9 +95,7 @@ def _build_dataframe(time_series_iterable, label=None, labels=None):  # pragma: 
     for time_series in time_series_iterable:
         pandas_series = pandas.Series(
             data=[_extract_value(point.value) for point in time_series.points],
-            index=[
-                point.interval.end_time.ToNanoseconds() for point in time_series.points
-            ],
+            index=[point.interval.end_time for point in time_series.points],
         )
         columns.append(pandas_series)
         headers.append(_extract_header(time_series))

--- a/google/cloud/monitoring_v3/_dataframe.py
+++ b/google/cloud/monitoring_v3/_dataframe.py
@@ -47,6 +47,10 @@ def _extract_labels(time_series):
 
 def _extract_value(typed_value):
     """Extract the value from a TypedValue."""
+    # There is no equivalent of WhichOneOf in proto-plus
+    # This may break if the field names have been altered in the
+    # proto-plus representation
+    # https://github.com/googleapis/proto-plus-python/issues/137
     value_type = monitoring_v3.TypedValue.pb(typed_value).WhichOneof("value")
     return getattr(typed_value, value_type)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -185,7 +185,7 @@ def docs(session):
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
         "sphinx-build",
-        # "-W",  # warnings as errors
+        "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
         "-b",

--- a/noxfile.py
+++ b/noxfile.py
@@ -185,7 +185,7 @@ def docs(session):
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(
         "sphinx-build",
-        "-W",  # warnings as errors
+        # "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
         "-b",

--- a/samples/snippets/v3/cloud-client/snippets.py
+++ b/samples/snippets/v3/cloud-client/snippets.py
@@ -35,13 +35,13 @@ def create_metric_descriptor(project_id):
     descriptor.metric_kind = ga_metric.MetricDescriptor.MetricKind.GAUGE
     descriptor.value_type = ga_metric.MetricDescriptor.ValueType.DOUBLE
     descriptor.description = "This is a simple example of a custom metric."
-    
+
     labels = ga_label.LabelDescriptor()
     labels.key = "TestLabel"
     labels.value_type = ga_label.LabelDescriptor.ValueType.STRING
     labels.description = "This is a test label"
     descriptor.labels.append(labels)
-    
+
     descriptor = client.create_metric_descriptor(
         name=project_name, metric_descriptor=descriptor
     )

--- a/samples/snippets/v3/cloud-client/snippets.py
+++ b/samples/snippets/v3/cloud-client/snippets.py
@@ -18,8 +18,8 @@ import pprint
 import time
 import uuid
 
-from google.api import metric_pb2 as ga_metric
 from google.api import label_pb2 as ga_label
+from google.api import metric_pb2 as ga_metric
 from google.cloud import monitoring_v3
 
 

--- a/synth.py
+++ b/synth.py
@@ -93,16 +93,19 @@ s.replace(
 templated_files = common.py_library(
     samples=True,  # set to True only if there are samples
     microgenerator=True,
+    unit_test_extras=["pandas"],
+    system_test_extras=["pandas"],
     cov_level=99
 )
 s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .coveragerc file
+
+# Don't treat warnings as errors.
+s.replace("noxfile.py", '[\"\']-W[\"\']', '# "-W"')
 
 # ----------------------------------------------------------------------------
 # Samples templates
 # ----------------------------------------------------------------------------
 python.py_samples(skip_readmes=True)
 
-# Don't treat warnings as errors.
-s.replace("noxfile.py", '[\"\']-W[\"\']', '# "-W"')
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)

--- a/synth.py
+++ b/synth.py
@@ -99,6 +99,9 @@ templated_files = common.py_library(
 )
 s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .coveragerc file
 
+# Don't treat docs (sphinx) warnings as errors.
+s.replace("noxfile.py", '[\"\']-W[\"\']', '# "-W"')
+
 # ----------------------------------------------------------------------------
 # Samples templates
 # ----------------------------------------------------------------------------

--- a/synth.py
+++ b/synth.py
@@ -99,9 +99,6 @@ templated_files = common.py_library(
 )
 s.move(templated_files, excludes=[".coveragerc"])  # microgenerator has a good .coveragerc file
 
-# Don't treat warnings as errors.
-s.replace("noxfile.py", '[\"\']-W[\"\']', '# "-W"')
-
 # ----------------------------------------------------------------------------
 # Samples templates
 # ----------------------------------------------------------------------------

--- a/tests/unit/test__dataframe.py
+++ b/tests/unit/test__dataframe.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import pandas
-except ImportError:
-    HAVE_PANDAS = False
-else:
-    HAVE_PANDAS = True  # pragma: NO COVER
 
+import pandas
 import unittest
+
+from google.api import metric_pb2
+from google.api import monitored_resource_pb2
+from google.api_core import datetime_helpers
+from google.cloud import monitoring_v3
+from google.cloud.monitoring_v3 import _dataframe
 
 
 PROJECT = "my-project"
@@ -52,26 +53,26 @@ ARRAY = [VALUES] * DIMENSIONS[0]
 
 
 def parse_timestamps():
-    from google.api_core import datetime_helpers
-
-    return [datetime_helpers.from_rfc3339(t).replace(tzinfo=None) for t in TIMESTAMPS]
+    return [pandas.Timestamp(t) for t in TIMESTAMPS]
 
 
 def generate_query_results():
-    from google.cloud.monitoring_v3 import types
-
     def P(timestamp, value):
-        interval = types.TimeInterval()
-        interval.start_time.FromJsonString(timestamp)
-        interval.end_time.FromJsonString(timestamp)
-        return types.Point(interval=interval, value={"double_value": value})
+        interval = monitoring_v3.TimeInterval()
+        interval.start_time = datetime_helpers.from_rfc3339(timestamp).replace(
+            tzinfo=None
+        )
+        interval.end_time = datetime_helpers.from_rfc3339(timestamp).replace(
+            tzinfo=None
+        )
+        return monitoring_v3.Point(interval=interval, value={"double_value": value})
 
     for metric_labels, resource_labels, value in zip(
         METRIC_LABELS, RESOURCE_LABELS, VALUES
     ):
-        yield types.TimeSeries(
-            metric=types.Metric(type=METRIC_TYPE, labels=metric_labels),
-            resource=types.MonitoredResource(
+        yield monitoring_v3.TimeSeries(
+            metric=metric_pb2.Metric(type=METRIC_TYPE, labels=metric_labels),
+            resource=monitored_resource_pb2.MonitoredResource(
                 type=RESOURCE_TYPE, labels=resource_labels
             ),
             metric_kind=METRIC_KIND,
@@ -80,12 +81,9 @@ def generate_query_results():
         )
 
 
-@unittest.skipUnless(HAVE_PANDAS, "No pandas")
 class Test__build_dataframe(unittest.TestCase):
     def _call_fut(self, *args, **kwargs):
-        from google.cloud.monitoring_v3._dataframe import _build_dataframe
-
-        return _build_dataframe(*args, **kwargs)
+        return _dataframe._build_dataframe(*args, **kwargs)
 
     def test_both_label_and_labels_illegal(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/test__dataframe.py
+++ b/tests/unit/test__dataframe.py
@@ -53,7 +53,8 @@ ARRAY = [VALUES] * DIMENSIONS[0]
 
 
 def parse_timestamps():
-    return [pandas.Timestamp(t) for t in TIMESTAMPS]
+    from google.api_core import datetime_helpers
+    return [datetime_helpers.from_rfc3339(t).replace(tzinfo=None) for t in TIMESTAMPS]
 
 
 def generate_query_results():

--- a/tests/unit/test__dataframe.py
+++ b/tests/unit/test__dataframe.py
@@ -54,6 +54,7 @@ ARRAY = [VALUES] * DIMENSIONS[0]
 
 def parse_timestamps():
     from google.api_core import datetime_helpers
+
     return [datetime_helpers.from_rfc3339(t).replace(tzinfo=None) for t in TIMESTAMPS]
 
 


### PR DESCRIPTION
The dataframe helper methods were being skipped because `pandas` was not installed in the unit test session. This re-enables those tests and makes the minimal number of fixes to get the unit tests passing again.

TODOs:
- Are datetimes being handled correctly?
- Is there a better way to do `WhichOneOf` with proto-plus? https://github.com/googleapis/proto-plus-python/issues/137

Fixes #90  🦕


Simple example:

```py
import datetime

from google.cloud import monitoring_v3
from google.cloud.monitoring_v3.query import Query
import pandas

# TODO: Change these to the desired project and metric_type
project_name = "my-project"
metric_type = "storage.googleapis.com/storage/object_count"

client = monitoring_v3.MetricServiceClient()

query = Query(client, project_name, metric_type=metric_type, end_time=None, days=7,)

df = query.as_dataframe()
print(df[:3])
```