### PR TITLE
 chore: fix flaky samples test due to truncated string

### DIFF
--- a/samples/snippets/v3/alerts-client/snippets.py
+++ b/samples/snippets/v3/alerts-client/snippets.py
@@ -30,9 +30,11 @@ def list_alert_policies(project_name):
     client = monitoring_v3.AlertPolicyServiceClient()
     policies = client.list_alert_policies(name=project_name)
     print(
-        tabulate.tabulate(
-            [(policy.name, policy.display_name) for policy in policies],
-            ("name", "display_name"),
+        str(
+            tabulate.tabulate(
+                [(policy.name, policy.display_name) for policy in policies],
+                ("name", "display_name"),
+            )
         )
     )
 


### PR DESCRIPTION
This PR fixes the flaky test reported in #149 where string `'snippets-test-enclcibdnr'`, as an example, is not found in string `'snippets-test-enclci...jects/'` because the string is truncated. We can avoid the issue by casting to `str()` before calling `print()`.

Fixes #149 🦕