### PR TITLE
chore: only enable/disable a single policy in test_enable_alert_policies

### DIFF
--- a/samples/snippets/v3/alerts-client/snippets_test.py
+++ b/samples/snippets/v3/alerts-client/snippets_test.py
@@ -125,7 +125,9 @@ def pochan():
 def test_list_alert_policies(capsys, pochan):
     snippets.list_alert_policies(pochan.project_name)
     out, _ = capsys.readouterr()
-    assert pochan.alert_policy.display_name in out
+    # Only check up to the first 20 characters of the display name
+    # as long strings printed to the console are truncated.
+    assert pochan.alert_policy.display_name[0:20] in out
 
 
 @pytest.mark.flaky(rerun_filter=delay_on_aborted, max_runs=5)

--- a/samples/snippets/v3/alerts-client/snippets_test.py
+++ b/samples/snippets/v3/alerts-client/snippets_test.py
@@ -136,7 +136,7 @@ def test_enable_alert_policies(capsys, pochan):
     # Having multiple projects will void these `sleep()` calls.
     # See also #3310
     time.sleep(2)
-    snippets.enable_alert_policies(pochan.project_name, True)
+    snippets.enable_alert_policies(pochan.project_name, True, "name='{}'".format(pochan.alert_policy.name))
     out, _ = capsys.readouterr()
     assert (
         "Enabled {0}".format(pochan.project_name) in out
@@ -144,7 +144,7 @@ def test_enable_alert_policies(capsys, pochan):
     )
 
     time.sleep(2)
-    snippets.enable_alert_policies(pochan.project_name, False)
+    snippets.enable_alert_policies(pochan.project_name, False, "name='{}'".format(pochan.alert_policy.name))
     out, _ = capsys.readouterr()
     assert (
         "Disabled {}".format(pochan.project_name) in out


### PR DESCRIPTION
This PR attempts to resolve #150 by only enabling/ disabling a single alert policy, rather than enabling/ disabling all alert polices in the specified project in order to reduce the output that we need to parse for the expected result. From the build log in #150 :`'"snippets-test-ugrikrch..."projects/python-docs-samples-tests-py37'`, the `...` indicates that information is being truncated which would cause flaky results. 

Fixes #150 🦕
