### PR TITLE
chore: clean up alert policies older than 1 hour in snippets test

### DIFF
--- a/samples/snippets/v3/alerts-client/snippets_test.py
+++ b/samples/snippets/v3/alerts-client/snippets_test.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+from datetime import datetime
 import random
 import string
 import time
@@ -62,14 +63,16 @@ class PochanFixture:
             monitoring_v3.NotificationChannelServiceClient()
         )
 
-        # delete all existing policies prior to testing
+        # delete all existing policies older than 1 hour prior to testing
         for policy in self.alert_policy_client.list_alert_policies(name=self.project_name):
-            try:
-                self.alert_policy_client.delete_alert_policy(
-                    name=policy.name
-                )
-            except NotFound:
-                print("Ignored NotFound when deleting a policy.")
+            seconds_since_creation = datetime.timestamp(datetime.utcnow())-datetime.timestamp(policy.creation_record.mutate_time)
+            if seconds_since_creation > 3600:
+                try:
+                    self.alert_policy_client.delete_alert_policy(
+                        name=policy.name
+                    )
+                except NotFound:
+                    print("Ignored NotFound when deleting a policy.")
 
     def __enter__(self):
         @retry(

--- a/samples/snippets/v3/alerts-client/snippets_test.py
+++ b/samples/snippets/v3/alerts-client/snippets_test.py
@@ -62,6 +62,15 @@ class PochanFixture:
             monitoring_v3.NotificationChannelServiceClient()
         )
 
+        # delete all existing policies prior to testing
+        for policy in self.alert_policy_client.list_alert_policies(name=self.project_name):
+            try:
+                self.alert_policy_client.delete_alert_policy(
+                    name=policy.name
+                )
+            except NotFound:
+                print("Ignored NotFound when deleting a policy.")
+
     def __enter__(self):
         @retry(
             wait_exponential_multiplier=1000,


### PR DESCRIPTION
As a next step in troubleshooting the failure from #149, I'd like to clean up the existing alert policies in the test environment before running tests.