### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,13 +1,15 @@
 {
-  "name": "monitoring",
-  "name_pretty": "Stackdriver Monitoring",
-  "product_documentation": "https://cloud.google.com/monitoring/docs",
-  "client_documentation": "https://googleapis.dev/python/monitoring/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_COMBO",
-  "repo": "googleapis/python-monitoring",
-  "distribution_name": "google-cloud-monitoring",
-  "api_id": "monitoring.googleapis.com"
+    "name": "monitoring",
+    "name_pretty": "Stackdriver Monitoring",
+    "product_documentation": "https://cloud.google.com/monitoring/docs",
+    "client_documentation": "https://googleapis.dev/python/monitoring/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_COMBO",
+    "repo": "googleapis/python-monitoring",
+    "distribution_name": "google-cloud-monitoring",
+    "api_id": "monitoring.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-monitoring",
     "distribution_name": "google-cloud-monitoring",
     "api_id": "monitoring.googleapis.com",
-    "default_version": "",
+    "default_version": "v3",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114