### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "monitoring",
     "name_pretty": "Stackdriver Monitoring",
     "product_documentation": "https://cloud.google.com/monitoring/docs",
-    "client_documentation": "https://googleapis.dev/python/monitoring/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/monitoring/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559785",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ with a few exceptions as noted on the individual method pages.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-monitoring.svg
    :target: https://pypi.org/project/google-cloud-monitoring/
 .. _Cloud Monitoring API: https://cloud.google.com/monitoring/api/ref_v3/rest/
-.. _Client Library Documentation: https://googleapis.dev/python/monitoring/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/monitoring/latest
 .. _Product Documentation:  https://cloud.google.com/monitoring/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.