### PR TITLE
chore: test minimum dependencies in python 3.7

### DIFF
--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -1,2 +1,10 @@
-# This constraints file is left inentionally empty
-# so the latest version of dependencies is installed
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List all library dependencies and extras in this file.
+# Pin the version to the lower bound.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have google-cloud-foo==1.14.0
+google-api-core==1.31.5
+proto-plus==1.15.0
+pandas==0.23.0
+protobuf==3.19.0

--- a/testing/constraints-3.7.txt
+++ b/testing/constraints-3.7.txt
@@ -6,5 +6,5 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.31.5
 proto-plus==1.15.0
-pandas==0.23.0
+pandas==0.23.2
 protobuf==3.19.0


### PR DESCRIPTION
Test the minimum supported dependencies in python 3.7 unit tests to prepare for dropping python 3.6