### PR TITLE
fix: add metric label example to the quickstart snippet

### DIFF
--- a/samples/snippets/v3/cloud-client/quickstart.py
+++ b/samples/snippets/v3/cloud-client/quickstart.py
@@ -25,6 +25,7 @@ def run_quickstart(project=""):
 
     series = monitoring_v3.TimeSeries()
     series.metric.type = "custom.googleapis.com/my_metric"
+    series.metric.labels["store_id"] = "Pittsburgh"
     series.resource.type = "gce_instance"
     series.resource.labels["instance_id"] = "1234567890123456789"
     series.resource.labels["zone"] = "us-central1-f"


### PR DESCRIPTION
Adds a code line that demonstrates setting a metric's label in addition to resource's label.
Align the code sample with similar samples in other languages.
